### PR TITLE
Necessary changes so hosh_exit frees all data appropriately

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -53,6 +53,7 @@ int hosh_unsetenv(char **args)
 /**
  * hosh_exit - exit the current child process & free what must be free'd
  * @args: Double pointer to the command and given args
+ * @input: The original input from the user
  *
  * Return: 0 if success, 1 if failure
  */

--- a/builtins.c
+++ b/builtins.c
@@ -56,12 +56,13 @@ int hosh_unsetenv(char **args)
  *
  * Return: 0 if success, 1 if failure
  */
-int hosh_exit(char **args)
+int hosh_exit(char **args, char *input)
 {
 	int status;
 
 	if (args[1] == NULL)
 	{
+		free(input);
 		free(args);
 		_exit(0);
 	}
@@ -73,6 +74,7 @@ int hosh_exit(char **args)
 			_puts("Illegal number\n");
 			return (1);
 		}
+		free(input);
 		free(args);
 		_exit(status);
 	}

--- a/check_builtins.c
+++ b/check_builtins.c
@@ -7,7 +7,7 @@
  * Return: the return value of the builtin called on success,
  * or -1 if it failed
  */
-int check_builtins(char **args)
+int check_builtins(char **args, char *input)
 {
 	builtins_t builtins[] = {
 		{"exit", hosh_exit},
@@ -21,7 +21,11 @@ int check_builtins(char **args)
 
 	len = _strlen(args[0]);
 	for (i = 0; builtins[i].name != NULL; i++)
+	{
+		if (_strncmp(args[0], "exit", 4) == 0)
+			return (builtins[0].func(args, input));
 		if (_strncmp(args[0], builtins[i].name, len) == 0)
 			return (builtins[i].func(args));
+	}
 	return (-1);
 }

--- a/loop.c
+++ b/loop.c
@@ -48,7 +48,7 @@ void loop(void)
 		if (input[0] != '\n' && input[0] != '#')
 		{
 			args = make_args(input);
-			if (check_builtins(args) == -1)
+			if (check_builtins(args, input) == -1)
 			{
 				inchild = 1;
 				firstarg = args[0];

--- a/shell.h
+++ b/shell.h
@@ -28,7 +28,7 @@ typedef struct addresses
 typedef struct builtins_s
 {
 	char *name;
-	int (*func)(char **);
+	int (*func)();
 } builtins_t;
 
 /* --Help Struct --*/
@@ -74,11 +74,12 @@ char *path_concat(char *s1, char *s2);
 char *_copypath(char *name);
 
 /* --Builtin Functions-- */
-int check_builtins(char **args);
+int check_builtins(char **args, char *input);
 int hosh_printenv(char **args);
 int hosh_setenv(char **args);
 int hosh_unsetenv(char **args);
-int hosh_exit(char **args);
+int hosh_exit(char **args, char *input);
+int hosh_help(char **args);
 
 /* --Env Functions-- */
 int _unsetenv(char *name);
@@ -103,7 +104,6 @@ char *_strcpy(char *dest, char *src);
 int _atoi(char *str);
 
 /* --Help Functions-- */
-int hosh_help(char **args);
 void help_exit(void);
 void help_env(void);
 void help_setenv(void);


### PR DESCRIPTION
Changed prototypes for hosh_exit & check_builtins to accept input as an argument.
Also changed check_builtins to run a specific builtin command for exit.
Minor change to shell.h: Moved hosh_help next to rest of builtin functions.